### PR TITLE
#603

### DIFF
--- a/site/helpers/route.php
+++ b/site/helpers/route.php
@@ -842,6 +842,22 @@ if ( ! is_null( $cfg_which_database) ) { $params["cfg_which_database"] = $cfg_wh
 	}
 
     /**
+	 * sportsmanagementHelperRoute::getNextMatchRoute()
+	 *
+     * @param mixed $project_id
+     * @param mixed $match_id
+     * @return string
+     */
+    public static function getNextMatchRoute($project_id, $match_id) {
+        $params = array();
+        $params['cfg_which_database'] = JFactory::getApplication()->input->getInt('cfg_which_database',0);
+        $params['s'] = JFactory::getApplication()->input->getInt('s',0);
+        $params['p'] = $project_id;
+        $params['mid'] = $match_id;
+        return sportsmanagementHelperRoute::getSportsmanagementRoute('matchreport',$params);
+    }
+
+    /**
      * sportsmanagementHelperRoute::getIcalRoute()
      *
      * @param mixed $projectid

--- a/site/views/teamplan/tmpl/default_plan.php
+++ b/site/views/teamplan/tmpl/default_plan.php
@@ -917,18 +917,14 @@ $link = sportsmanagementHelperRoute::getSportsmanagementRoute('matchreport',$rou
 			?>
 		<td><?php
 		if (!$match->cancel) {
-			if (isset($match->team1_result))
+            $link=sportsmanagementHelperRoute::getNextMatchRoute($this->project->slug,$match->id);
+            if (isset($match->team1_result))
 			{
 				if ($this->config['show_matchreport_image']) {
 					$href_text = JHtml::image($this->config['matchreport_image'], JText::_('COM_SPORTSMANAGEMENT_TEAMPLAN_VIEW_MATCHREPORT'));
 				} else {
 					$href_text = JText::_('COM_SPORTSMANAGEMENT_TEAMPLAN_VIEW_MATCHREPORT');
 				}
-$routeparameter['cfg_which_database'] = JFactory::getApplication()->input->getInt('cfg_which_database',0);
-$routeparameter['s'] = JFactory::getApplication()->input->getInt('s',0);
-$routeparameter['p'] = $this->project->slug;
-$routeparameter['mid'] = $match->id;
-$link = sportsmanagementHelperRoute::getSportsmanagementRoute('matchreport',$routeparameter);
 				
 				$viewReport=JHtml::link($link, $href_text);
 				echo $viewReport;
@@ -940,7 +936,7 @@ $link = sportsmanagementHelperRoute::getSportsmanagementRoute('matchreport',$rou
 				} else {
 					$href_text = JText::_('COM_SPORTSMANAGEMENT_TEAMPLAN_VIEW_MATCHPREVIEW');
 				}
-				$link=sportsmanagementHelperRoute::getNextMatchRoute($this->project->slug,$match->id);
+
 				$viewPreview=JHtml::link($link, $href_text);
 				echo $viewPreview;
 			}


### PR DESCRIPTION
- getNextMatchRoute Methode hat gefehlt.
- Der Link ist bei Spielbericht oder Spielvorschau gleich, deswegen wurde die Erstellung der Variable vorgezogen