### PR TITLE
Update prediction.php

### DIFF
--- a/site/models/prediction.php
+++ b/site/models/prediction.php
@@ -1028,8 +1028,6 @@ $db->disconnect(); // See: http://api.joomla.org/cms-3/classes/JDatabaseDriver.h
         $groupNames = '';
         // Application Instanz holen
         $app = Factory::getApplication();
-        // ACL Instanz holen
-        $acl = Factory::getACL();
         // JUserobjekt holen
         $user = Factory::getUser();
         


### PR DESCRIPTION
Joomla4: getACL() is deprecated
"Call to undefined method Joomla\CMS\Factory::getACL()"