### PR TITLE
Update prediction.php

### DIFF
--- a/site/models/prediction.php
+++ b/site/models/prediction.php
@@ -2233,10 +2233,11 @@ $output .= '>'.Text::_('COM_SPORTSMANAGEMENT_ALL_PROJECTS').'</option>';
 		else{$tipp=null;}
     }
 
-		$points		= NULL;
-		$top		= NULL;
-		$diff		= NULL;
-		$tend		= NULL;
+		$points		= 0;
+		$top		= 0;
+		$diff		= 0;
+		$tend		= 0;
+		
 
     if ( $predictionProject->mode == 1 )	// TOTO prediction Mode
 		{


### PR DESCRIPTION
Fehlermeldung Forumsbeitrag  #13220: "Mehr Top-Tipps gezählt als erspielt wurde"
"0" anstelle von "NULL" für die korrekte Aktualisierung der Einträge in "sportsmanagement_prediction_result'