### PR TITLE
Fix mod_calendar

### DIFF
--- a/admin/models/fields/color.php
+++ b/admin/models/fields/color.php
@@ -47,7 +47,7 @@ class JFormFieldColor extends \JFormFieldText
 	 * @param mixed $group
 	 * @return
 	 */
-	public function setup(& $element, $value, $group = null)
+	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
 		$return= parent::setup($element, $value, $group);
 		$this->element['class'] = $this->element['class'].' color';

--- a/modules/mod_sportsmanagement_calendar/helper.php
+++ b/modules/mod_sportsmanagement_calendar/helper.php
@@ -388,13 +388,14 @@ class JSMCalendar extends PHPCalendar
 	{
 		$getquery = Factory::getApplication()->input->get('GET'); //get the GET query
 		$calendarLink= Uri::current().'?'; //get the current url, without the GET query; and add "?", to set the GET vars
-
-		foreach($getquery as $key => $value){  /*this bucle goes through every GET variable that was in the url*/
-			if($key!='month' AND $key!='year' AND $key!='day' AND $value){ /*the month,year, and day Variables must be diferent of the current ones, because this is a link for a diferent month */
-				$calendarLink.= $key . '=' . $value . '&amp;';
-			}
+		if (!empty($getquery)) {
+			foreach($getquery as $key => $value){  /*this bucle goes through every GET variable that was in the url*/
+				if($key!='month' AND $key!='year' AND $key!='day' AND $value){ /*the month,year, and day Variables must be diferent of the current ones, because this is a link for a diferent month */
+					$calendarLink.= $key . '=' . $value . '&amp;';
+				}
+			}	
+			$calendarLink.='month='.$month.'&amp;year='.$year; //add the month and the year that was passed to the function to the GET string
 		}
-		$calendarLink.='month='.$month.'&amp;year='.$year; //add the month and the year that was passed to the function to the GET string
 		return $calendarLink;
 	}
 

--- a/modules/mod_sportsmanagement_calendar/mod_sportsmanagement_calendar.php
+++ b/modules/mod_sportsmanagement_calendar/mod_sportsmanagement_calendar.php
@@ -113,7 +113,7 @@ else
 }
 $calendar = $helper->showCal($params,$year,$month,$ajax,$module->id);
 ?>           
-<div class="<?php echo $params->get('moduleclass_sfx'); ?>" id="<?php echo $module->module; ?>-<?php echo $module->id; ?>">
+<div id="<?php echo $module->module; ?>-<?php echo $module->id; ?>">
 <?PHP
 require(ModuleHelper::getLayoutPath($module->module));
 ?>


### PR DESCRIPTION
check for emtpy variable $getquery

remove class in div
wie schon in einem anderen Modul (clubicon) musste ich die class-Kennzeichnung entfernen ansonsten wird das Modul angepasst und anschließend noch einmal der Kalender selbst.