### PR TITLE
Module teamplayers upgrade

### DIFF
--- a/modules/mod_sportsmanagement_teamplayers/css/mod_sportsmanagement_teamplayers.css
+++ b/modules/mod_sportsmanagement_teamplayers/css/mod_sportsmanagement_teamplayers.css
@@ -1,41 +1,62 @@
 @CHARSET "UTF-8";
 
-
-.modjlgteamplayers
+.modteamplayers
 {
-display: block;
-margin-left: auto;
-margin-right: auto;
-width: 100%;
-vertical-align: middle;
-text-align:center;
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+	width: 100%;
+	vertical-align: middle;
+	text-align:center;
 }
 
-div.modjlteamplayers .projectname {
+.projectname {
+	font-size: 20px;
+	margin-top: 3px;
 	font-weight: bold;
-text-align: center;
 }
 
-div.modjlgteamplayers .playerlink {
-text-align: center;
-vertical-align: middle;
-}
-div.modjlgteamplayers .teamname {
-text-align: center;
-vertical-align: middle;
-}
-div.modjlgteamplayers table {
+.player_position {
+	font-size: 14px;
+	margin-top: 1px;
+	font-weight: bold;
 }
 
-div.modjlgteamplayers td {
+.player_mins {
+	font-size: 18px;
+	margin-top: 1px;
+	font-weight: bold;
 }
 
-ul.modjlgplayer{
-display: block;
-list-style: none;
+div.modteamplayers .playerlink {
+	text-align: center;
+	vertical-align: middle;
+}
+div.modteamplayers .teamname {
+	text-align: center;
+	vertical-align: middle;
 }
 
-ul.modjlgposition{
-list-style: none;
-display: block;
+div.modteamplayers table {
+}
+
+div.modteamplayers td {
+}
+
+ul.modplayer{
+	display: block;
+	list-style: none;
+}
+
+ul.modposition{
+	list-style: none;
+	display: block;
+}
+
+.bx-prev {
+    margin-left: -70px;
+}
+
+.bx-next {
+    margin-right: -70px;
 }

--- a/modules/mod_sportsmanagement_teamplayers/helper.php
+++ b/modules/mod_sportsmanagement_teamplayers/helper.php
@@ -3,11 +3,13 @@
  *
  * SportsManagement ein Programm zur Verwaltung für alle Sportarten
  *
- * @version    1.0.05
+ * @version    1.1.0
  * @package    Sportsmanagement
  * @subpackage mod_sportsmanagement_teamplayers
  * @file       helper.php
  * @author     diddipoeler, stony, svdoldie und donclumsy (diddipoeler@gmx.de)
+ * @modded	   llambion (2020)
+ *             Added players carrousel, mins played and position fields 
  * @copyright  Copyright: © 2013 Fussball in Europa http://fussballineuropa.de/ All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
@@ -103,7 +105,7 @@ class modSportsmanagementTeamPlayersHelper
 		$flag = "";
 
 		if ($params->get('show_player_flag'))
-		{
+		{		
 			$flag = JSMCountries::getCountryFlag($item->country) . "&nbsp;";
 		}
 
@@ -124,12 +126,102 @@ class modSportsmanagementTeamPlayersHelper
 			$routeparameter['pid']                = $item->person_slug;
 			$link                                 = sportsmanagementHelperRoute::getSportsmanagementRoute('player', $routeparameter);
 
-			echo $flag . HTMLHelper::link($link, $text);
+			return $flag . HTMLHelper::link($link, $text);
 		}
 		else
 		{
-			echo '<i>' . Text::sprintf('%1$s', $flag . $text) . '</i>';
+			return '<i>' . Text::sprintf('%1$s', $flag . $text) . '</i>';
 		}
 
 	}
-}
+
+	/**
+	 * modSportsmanagementTeamPlayersHelper::getPlayerLink()
+	 *
+	 * @param   mixed  $item
+	 * @param   mixed  $params
+	 * @param   mixed  $project
+	 *
+	 * @return player_name_link, flag_link
+	 */
+	public static function getPlayerLinkAndFlag($item, $params, $project, $module)
+	{
+		$flag = "";
+		$return = array();
+
+		if ($params->get('show_player_flag'))
+		{		
+			$flag = JSMCountries::getCountryFlag($item->country) . "&nbsp;";
+		}
+
+		$text = "<i>" . sportsmanagementHelper::formatName(
+				null, $item->firstname,
+				$item->nickname,
+				$item->lastname,
+				$params->get("name_format")
+			) . "</i>";
+
+		if ($params->get('show_player_link'))
+		{
+			$routeparameter                       = array();
+			$routeparameter['cfg_which_database'] = $params->get('cfg_which_database');
+			$routeparameter['s']                  = $params->get('s');
+			$routeparameter['p']                  = $item->project_slug;
+			$routeparameter['tid']                = $item->team_slug;
+			$routeparameter['pid']                = $item->person_slug;
+			$link                                 = sportsmanagementHelperRoute::getSportsmanagementRoute('player', $routeparameter);
+
+			$return['name'] = HTMLHelper::link($link, $text);
+			$return['flag'] = $flag;
+
+			return $return;
+		}
+		else
+		{
+			
+			$return['name'] = Text::sprintf('%1$s', $text);
+			$return['flag'] = $flag;
+			
+			return $return;
+		}
+
+	}
+
+
+
+	/**
+	 * modSportsmanagementTeamPlayersHelper::getPlayerMinsPlayed()
+	 *
+	 * @param   mixed  $item
+	 * @param   mixed  $params
+	 * @param   mixed  $project
+	 *
+	 * @return void
+	 */
+	public static function getPlayerMinsPlayed($item, $params, $project, $module, $time_for_match)
+	{
+		$mainframe = Factory::getApplication();
+
+		$p = (int) $params->get('p');	
+		
+		if (!class_exists('sportsmanagementModelPlayer'))
+		{
+			JLoader::import('components.com_sportsmanagement.models.player', JPATH_SITE);
+		}
+
+		$model                                   = BaseDatabaseModel::getInstance('Player', 'sportsmanagementModel');
+		sportsmanagementModelProject::$projectid = $p;
+		$project                                 = sportsmanagementModelProject::getProject();
+		$project->team_name                      = $team_name;
+		$model::$projectid                       = $p;
+		$model::$personid                        = $item->pid;
+        $model::$teamplayerid					 = $item->playerid;
+		
+        // Tengo que pasar id_jugador, tiempo_de_juego, null, mull, proyecto
+		
+		return $model->getTimePlayed($item->playerid, $time_for_match, NULL, NULL , $p);		
+			
+	}	
+
+
+} // End class

--- a/modules/mod_sportsmanagement_teamplayers/language/en-GB/en-GB.mod_sportsmanagement_teamplayers.ini
+++ b/modules/mod_sportsmanagement_teamplayers/language/en-GB/en-GB.mod_sportsmanagement_teamplayers.ini
@@ -1,18 +1,19 @@
-; @package sportsmanagement
-; @subpackage mod_sportsmanagement_teamplayers
-; @copyright    Copyright (c) 2014-2019 JSM. All rights reserved.
-; @license      GNU General Public License version 2 or later; see LICENSE.txt
-; Note : All ini files need to be saved as UTF-8
-;
+; @file		mod_sportsmanagement_teamplayers.ini
+; Copyright (C) 2015 JSM-Team. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; @author	stony - JSM Team
+; Backend modul configuration
+; @package	SPORTSMANAGEMENT
+; Note : All ini files need to be saved as UTF-8 - No BOM
 
-; ---- GLOBAL SETTINGS
+; ---- global settings
 MOD_SPORTSMANAGEMENT_BASIC_DESC="Basic settings"
 COM_SPORTSMANAGEMENT_SETTINGS_USE_JOOMLA_DATABASE_TITLE="use external database."
 COM_SPORTSMANAGEMENT_SETTINGS_USE_JOOMLA_DATABASE_DESC="use external database."
 COM_SPORTSMANAGEMENT_XML_SELECT_SEASON_LABEL="Select a season"
 COM_SPORTSMANAGEMENT_XML_SELECT_SEASON_DESCR="Selection: Select a season from the list."
 
-; BACKEND CONFIGURATION
+; Backend configuration
 MOD_SPORTSMANAGEMENT_TEAMPLAYERS="JSM - Module Teamplayers"
 ;MOD_SPORTSMANAGEMENT_TEAMPLAYERS_XML_DESC="This module displays a list of selected team players."
 MOD_SPORTSMANAGEMENT_TEAMPLAYERS_XML_DESC="<style type='text/css'>fieldset img {float:none !important;}</style><div class='.clear-block'><center><h3 style='color:#194172;'><strong>This module shows the players of a team</strong></h3><br /><br /><br /><a title= 'Homepage' target='_blank' href='http://www.joomla-sports-management.de'> <img src= '../administrator/components/com_sportsmanagement/assets/icons/logo_transparent.png' </a> <br /> A ccomponent for all sports! <br /> <a href='http://www.fussballineuropa.de' target='_blank'>Copyright : &copy; Fussball in Europa</a> <br /> <a target='blank' href='http://mantisbugtracker.fussballineuropa.de/my_view_page.php'>Bug-Tracker</a><br /><a target='blank' href='http://smwiki.diddipoeler.de/index.php'>Online-Help</a><br /></center></div>"
@@ -39,6 +40,28 @@ MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_LOGO_LABEL="Show logo?"
 MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_LOGO_LABEL_DESC="You can display the 'small' logo of the team's club, or the team country flag"
 MOD_SPORTSMANAGEMENT_TEAMPLAYERS_CLUB_LOGO="Club Logo"
 MOD_SPORTSMANAGEMENT_TEAMPLAYERS_COUNTRY_FLAG="Country flag"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_MODE="Choose template"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_MODE_DESC="Choose template. List or Carrousel"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_MODE="Carrusel Orientation"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_MODE_DESC="Orientation of the Carousel. Vertical or Horizontal"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_MAX_SLIDES="Number of images to display"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_MAX_SLIDES_DESC="The number of images to display simultaneously"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_AUTO="Auto slider"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_AUTO_DESC="Carousel turns slides automatically"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_RESPONSIVE="Responsive design"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_RESPONSIVE_DESC="Use Responsive design"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_SLIDER_NAV="Show nav items"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_SLIDER_NAV_DESC="Show prev and next icons"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_SLIDER_PAG="Show pagination indexes"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_SLIDER_PAG_DESC="Show pagination icons"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_MINS_PLAYED="Show mins played"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_MINS_PLAYED_DESC="Show mins played"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_POSITIONS="Show positions"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_POSITIONS_DESC="Show positions"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_SPEED="Slider speed in ms"
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_SPEED_DESC="Slider speed in ms. Default value 500ms"
 
-; FRONTEND
+MOD_SPORTSMANAGEMENT_TEAMPLAYERS_MINS_PLAYED="Mins played"
+
+; Frontend
 MOD_SPORTSMANAGEMENT_TEAMPLAYERS_JL_PERSON_PICTURE="Picture of"

--- a/modules/mod_sportsmanagement_teamplayers/mod_sportsmanagement_teamplayers.php
+++ b/modules/mod_sportsmanagement_teamplayers/mod_sportsmanagement_teamplayers.php
@@ -3,11 +3,13 @@
  *
  * SportsManagement ein Programm zur Verwaltung für alle Sportarten
  *
- * @version    1.0.05
+ * @version    1.1.0
  * @package    Sportsmanagement
  * @subpackage mod_sportsmanagement_teamplayers
  * @file       mod_sportsmanagement_teamplayers.php
  * @author     diddipoeler, stony, svdoldie und donclumsy (diddipoeler@gmx.de)
+ * @modded	   llambion (2020)
+ *             Added players carrousel, mins played and position fields
  * @copyright  Copyright: © 2013 Fussball in Europa http://fussballineuropa.de/ All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
@@ -90,6 +92,35 @@ $document = Factory::getDocument();
  * add css file
  */
 $document->addStyleSheet(Uri::base() . 'modules' . DIRECTORY_SEPARATOR . $module->module . DIRECTORY_SEPARATOR . 'css' . DIRECTORY_SEPARATOR . $module->module . '.css');
+
+$document->addScript(Uri::base().'modules' . DIRECTORY_SEPARATOR . $module->module. DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . 'default.js');
+
+
+// add files for slider
+//$document->addScript('https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js');  //si lo añado falla
+$document->addScript('https://cdnjs.cloudflare.com/ajax/libs/bxslider/4.2.15/jquery.bxslider.min.js');
+$document->addStyleSheet('https://cdnjs.cloudflare.com/ajax/libs/bxslider/4.2.15/jquery.bxslider.min.css');
+
+
+$document->addScriptDeclaration("
+
+    var $jQ = jQuery.noConflict();
+
+    $jQ(document).ready(function(){
+        $jQ('.bxslider').bxSlider({
+            mode: 'fade',
+            captions: true,
+            touchEnabled: true,
+            responsive: true,
+            controls: true,
+            auto: true,
+            pager:true,
+            adaptiveHeight: true,
+            slideWidth: 603        });
+    });
+
+");
+
 
 ?>
 <div class="<?php echo $params->get('moduleclass_sfx'); ?>"

--- a/modules/mod_sportsmanagement_teamplayers/mod_sportsmanagement_teamplayers.xml
+++ b/modules/mod_sportsmanagement_teamplayers/mod_sportsmanagement_teamplayers.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="module" version="2.5" client="site" method="upgrade">
 	<name>MOD_SPORTSMANAGEMENT_TEAMPLAYERS</name>
-	<creationDate>2014-03-13</creationDate>
+	<creationDate>2020-09-03</creationDate>
 	<author>JSM-TEAM</author>
 	<authorEmail>diddipoeler@arcor.de</authorEmail>
 	<authorUrl>http://www.fussballineuropa.de</authorUrl>
 	<license>GNU/GPL</license>
 	<copyright>Copyright (c) 2014 diddipoeler</copyright>
-	<version>1.0</version>
+	<version>1.1.0</version>
 	<description>MOD_SPORTSMANAGEMENT_TEAMPLAYERS_XML_DESC</description>
 
 	<files>
@@ -114,9 +114,74 @@ description="Debug Modus">
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
+				<field name="show_mins_played" type="extensionradiobutton" default="1" class="radio btn-group btn-group-yesno"
+					label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_MINS_PLAYED" 
+					description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_MINS_PLAYED_DESC">
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>	
+				</field>
+				<field name="show_positions" type="extensionradiobutton" default="1" class="radio btn-group btn-group-yesno"
+					label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_POSITIONS" 
+					description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_POSITIONS_DESC">
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>	
+				</field>				
 				<field name="name_format" type="nameformat"
 					label="COM_SPORTSMANAGEMENT_FES_PLAYER_PARAM_LABEL_NAME_FORMAT" 
-					description="COM_SPORTSMANAGEMENT_FES_PLAYER_PARAM_DESCR_NAME_FORMAT" />
+					description="COM_SPORTSMANAGEMENT_FES_PLAYER_PARAM_DESCR_NAME_FORMAT" />							
+							
+					
+				<field name="template" type="list" default="L" 
+					label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_MODE"
+					description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_MODE_DESC">
+					<option value="L">LIST</option>
+					<option value="C">CARROUSEL</option>
+				</field>						
+
+				<field name="slider_mode" type="list" default="H" 
+					label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_MODE"
+					description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_MODE_DESC">
+					<option value="H">Horizontal</option>
+					<option value="V">Vertical</option>
+				</field>	
+
+				<field 	name="slider_speed" type="text" default="500"
+						label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_SPEED" 
+						description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_SPEED_DESC" />
+						
+				<field name="slider_auto" type="extensionradiobutton" default="1" class="radio btn-group btn-group-yesno"
+					label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_AUTO" 
+					description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_AUTO_DESC">
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+				<field 	name="max_slides" type="text" default="3"
+						label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_MAX_SLIDES" 
+						description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_MAX_SLIDES_DESC" />				
+				
+				<field name="slider_responsive" type="extensionradiobutton" default="1" class="radio btn-group btn-group-yesno"
+					label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_RESPONSIVE" 
+					description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SLIDER_RESPONSIVE_DESC">
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>				
+
+				<field name="slider_navigation" type="extensionradiobutton" default="1" class="radio btn-group btn-group-yesno"
+					label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_SLIDER_NAV" 
+					description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_SLIDER_NAV_DESC">
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>	
+				
+				<field name="slider_pagination" type="extensionradiobutton" default="1" class="radio btn-group btn-group-yesno"
+					label="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_SLIDER_PAG" 
+					description="MOD_SPORTSMANAGEMENT_TEAMPLAYERS_SHOW_SLIDER_PAG_DESC">
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>					
+
+					
+			
 			</fieldset>
 				<fieldset
 					name="advanced">

--- a/modules/mod_sportsmanagement_teamplayers/tmpl/default.php
+++ b/modules/mod_sportsmanagement_teamplayers/tmpl/default.php
@@ -3,11 +3,13 @@
  *
  * SportsManagement ein Programm zur Verwaltung für alle Sportarten
  *
- * @version    1.0.05
+ * @version    1.1.0
  * @package    Sportsmanagement
  * @subpackage mod_sportsmanagement_teamplayers
  * @file       default.php
  * @author     diddipoeler, stony, svdoldie und donclumsy (diddipoeler@gmx.de)
+ * @modded	   llambion (2020)
+ *             Added players carrousel, mins played and position fields
  * @copyright  Copyright: © 2013 Fussball in Europa http://fussballineuropa.de/ All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
@@ -15,37 +17,452 @@
 defined('_JEXEC') or die('Restricted access');
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\Router\Route;
 
 // check if any players returned
 $items = count($list['roster']);
 
 if (!$items)
 {
-	echo '<p class="modjlgteamplayers">' . Text::_('NO ITEMS') . '</p>';
+	echo '<p class="modteamplayers">' . Text::_('NO ITEMS') . '</p>';
 
 	return;
-} ?>
+} 
 
-<div class="modjlgteamplayers"><?php if ($params->get('show_project_name', 0)) : ?>
-        <p class="projectname"><?php echo $list['project']->name; ?></p>
-	<?php endif; ?>
+$mode = $params->get('template');
+
+// mins per match
+$time_for_match = $list['project']->game_regular_time;
+
+//var_dump($list['project']);
+
+			?>
+
+			<div class="container-fluid">
+
+			<?	
 
 
-    <ul>
-        <h1>
+switch ($mode)
+{
+	/**
+	 *
+	 * HTML Template
+	 */
+	case 'L':
+	
+?>
+			<?php if ($params->get('show_project_name', 0)) : ?>
+			<div class="projectname"><?php echo $list['project']->name; ?></div>
+			<?php endif; ?>
+	
+
 			<?php if ($params->get('show_team_name', 0)) : ?>
-			<?php echo $list['project']->team_name; ?>
-<?php endif; ?></div>
-</h1>
-<?php foreach (array_slice($list['roster'], 0, $params->get('limit', 24)) as $items) : ?>
-    <li>
-        <ul>
-			<?php foreach (array_slice($items, 0, $params->get('limit', 24)) as $item) : ?>
-                <li><?php
-					echo modSportsmanagementTeamPlayersHelper::getPlayerLink($item, $params, $list['project'], $module);
-					?></li>
+			<div class="projectname"><?php echo $list['project']->team_name; ?></div>
+			<?php endif; ?>
+
+			<?
+			/* Llambion, añado la posicion de los jugadores */
+			$pos = "";
+			$oldpos = "";
+			?> 
+
+			<table class="table">
+			<tbody>
+			<tr class="sectiontableheader">
+				<td class="eventtype">Jugador</td>
+				<?
+					if ($params->get('show_mins_played') == 1)
+					{				
+					?>		
+						<td class="eventtype">Mins</td>
+					<?	
+					}
+				?>	
+			</tr>
+
+ 
+           <? 
+			
+			$players = array(); 
+			$plink ="";
+			$mins="";
+			
+			?>
+			
+			<?php foreach (array_slice($list['roster'], 0, $params->get('limit', 24)) as $items) : ?>
+
+				<?php foreach (array_slice($items, 0, $params->get('limit', 24)) as $item) : ?>
+				
+                    <?				
+	                 $plink = modSportsmanagementTeamPlayersHelper::getPlayerLink($item, $params, $list['project'], $module);			
+					 $mins  = modSportsmanagementTeamPlayersHelper::getPlayerMinsPlayed($item, $params, $list['project'], $module, $time_for_match);		
+					 
+	                 array_push ($players, array('posicion'=>$item->position, 'jugador'=>$plink, 'mins_played'=>$mins) );			  
+					 
+					 ?>
+			
+				<?php endforeach; ?>
+
 			<?php endforeach; ?>
-        </ul>
-    </li>
-<?php endforeach; ?>
-</ul>
+			
+<?
+
+			if ($params->get('show_positions') == 0)
+				{	
+							// Sort criteria
+				$sortCriteria =  array('mins_played' => array(SORT_DESC, SORT_NUMERIC)
+										);
+				}
+			else
+				{	
+							// Sort criteria
+				$sortCriteria =  array('posicion' => array(SORT_DESC, SORT_STRING),
+									   'mins_played' => array(SORT_DESC, SORT_NUMERIC)
+										);
+				}
+
+			//Sort Array
+			$sortedData = MultiSort($players, $sortCriteria, true);
+							
+			$max=sizeof($sortedData);
+			$pos = $sortedData[0]['posicion'];
+			$odd = false;
+				
+			for($i=0; $i<$max; $i++) {
+					
+				$pos = $sortedData[$i]['posicion'];
+					
+				if ($params->get('show_positions') == 1)
+				{							
+					if($pos <> $oldpos )
+						{
+						?>
+						<td><div class="player_position"><?php echo $sortedData[$i]['posicion']; ?></div></td>
+		
+						<?php
+						}
+				}
+				$oldpos = $pos; 
+				if ($odd)
+					{
+					  ?>						
+					  <tr class="sectiontableentry1">
+					  <?
+					  $odd = !$odd;
+					}  
+				else
+					{
+					  ?>						
+					  <tr class="sectiontableentry2">
+					  <?
+					  $odd = !$odd;
+					}
+				?>
+				<td>	
+				<?php echo $sortedData[$i]['jugador']; ?>					
+				</td>
+				</div></div>
+				<?
+				if ($params->get('show_mins_played') == 1)
+					{
+					?>	
+					<td>
+					<?php echo $sortedData[$i]['mins_played']; 	?>					
+					</td>
+					<?
+					}
+				?>
+				</tr>
+				<?
+			} // end for			
+			?>			
+						
+			
+			</tr>
+			</tbody>
+			</table>
+
+		</div>
+	</div>	
+	<?php
+	break;
+
+	/**
+	 *
+	 * Carrousel mode template
+	 */
+
+	case 'C':	
+?>	
+			<?php
+            
+			if ($params->get('show_project_name', 0)) : ?>
+			<div class="projectname"><?php echo $list['project']->name; ?></div>
+			<?php endif; ?>
+	
+
+			<?php if ($params->get('show_team_name', 0)) : ?>
+			<div class="projectname"><?php echo $list['project']->team_name; ?></div>
+			<?php endif; ?>
+
+			<?
+			
+			$players = array(); 
+			$plink ="";
+			$mins="";
+			
+			?>
+			
+			<?php foreach (array_slice($list['roster'], 0, $params->get('limit', 24)) as $items) : ?>
+
+				<?php foreach (array_slice($items, 0, $params->get('limit', 24)) as $item) : ?>
+				
+                    <?				
+	                 $plink = modSportsmanagementTeamPlayersHelper::getPlayerLinkAndFlag($item, $params, $list['project'], $module);			
+					 $mins  = modSportsmanagementTeamPlayersHelper::getPlayerMinsPlayed($item, $params, $list['project'], $module, $time_for_match);
+					 $image = $item->picture;
+					 
+	                 array_push ($players, array('posicion'=>$item->position, 'jugador'=>$plink['name'], 'flag'=>$plink['flag'], 'mins_played'=>$mins,'player_image'=>$image) );			  
+					 
+					 ?>
+			
+				<?php endforeach; ?>
+
+			<?php endforeach; ?>
+
+			<?
+			if ($params->get('show_positions') == 0)
+				{	
+							// Sort criteria
+				$sortCriteria =  array('mins_played' => array(SORT_DESC, SORT_NUMERIC)
+										);
+				}
+			else
+				{	
+							// Sort criteria
+				$sortCriteria =  array('posicion' => array(SORT_DESC, SORT_STRING),
+									   'mins_played' => array(SORT_DESC, SORT_NUMERIC)
+										);
+				}
+
+			//Sort Array
+			$sortedData = MultiSort($players, $sortCriteria, true);
+							
+			$max=sizeof($sortedData);
+			$pos = $sortedData[0]['posicion'];
+			$odd = false;
+					
+			?>	
+			
+			<ul class="tukuslider">
+			
+			<?
+			for($i=0; $i<$max; $i++) {
+					
+				$pos = $sortedData[$i]['posicion'];	
+				$image = "";
+
+				if (file_exists(JPATH_BASE . '/' . $sortedData[$i]['player_image']) && $sortedData[$i]['player_image'] != '')
+						{
+							$image = Uri::base() . '/' . $sortedData[$i]['player_image'];
+						}
+                        elseif (file_exists(JPATH_BASE . '/' . $sortedData[$i]['player_image']) && $sortedData[$i]['player_image'] != '')
+						{
+							$image = Uri::base() . '/' . $sortedData[$i]['player_image'];
+						}	
+				
+				?>
+				
+				<div class="slide">
+				
+					<div style="width: 150px;
+								height:210px;
+								padding: 10px 10px 20px 10px;
+								border: 1px solid #BFBFBF;
+								background-color: white;
+								box-shadow: 10px 10px 5px #aaaaaa;">
+				
+				     <? echo '				
+						<div style="position: absolute; 
+									top: 50px;
+									width: 140px;
+									height:140px;
+									background-size: contain;
+									background-repeat: no-repeat;
+									background-position: 50% 50%;
+									background-image: url(' . $image . ');
+									"> ';
+						?>	
+									
+						</div>
+
+
+						<? // Player's flag
+							if ($params->get('show_player_flag') == 1)
+								{
+						?>						
+									<div style="position: absolute; top: 10px; left: 10px;">	
+									<?	echo $sortedData[$i]['flag'] .'<br>'; ?>
+									</div>
+						<?
+								}
+						?>										
+
+						<div style="position: absolute; top: 5px; left: 30px;">	
+							<?	echo $sortedData[$i]['jugador'] .'<br>'; ?>
+						</div>
+
+						
+						<? // Mins played
+							if ($params->get('show_positions') == 1)
+								{
+						?>					
+									<div style="position: absolute; bottom: 25px; left: 10px; font-size: 15px;">	
+									<?	echo $sortedData[$i]['posicion'] .'<br>'; ?>
+									</div>
+						<?
+								}
+						?>	
+					
+						<?
+							if ($params->get('show_mins_played') == 1)
+								{
+						?>					
+									<div style="position: absolute; bottom: 5px; left: 10px;">	
+									<?	echo Text::_('MOD_SPORTSMANAGEMENT_TEAMPLAYERS_MINS_PLAYED') .', ' . $sortedData[$i]['mins_played'] .'<br>'; ?>
+									</div>				
+						<?
+								}
+						?>									
+
+					</div>
+				</div>
+
+
+			<?	
+	
+			} // end for
+
+			// Calc horizontal width
+			if ($params->get('slider_mode') == 'H')
+				{	
+				  $slider_width = $params->get('max_slides') * 65;
+				  $slider_mode = 'horizontal';
+				}
+			else
+				{
+				  $slider_mode = 'vertical';
+				  $slider_width = 180;
+				}			
+					
+			// responsive
+			if ($params->get('slider_responsive') == 1)
+				{				
+				  $responsive = 'true';
+				}
+			else
+				{				
+				  $responsive = 'false';
+				}
+			// auto slider	
+			if ($params->get('slider_auto') == 1)
+				{				
+				  $auto_slider = 'true';
+				}
+			else
+				{				
+				  $auto_slider = 'false';
+				}				
+			// navigation controls
+			if ($params->get('slider_navigation') == 1)
+				{				
+				  $navigation = 'true';
+				}
+			else
+				{				
+				  $navigation = 'false';
+				}				
+			// pagigation controls
+			if ($params->get('slider_pagination') == 1)
+				{				
+				  $pagination = 'true';
+				}
+			else
+				{				
+				  $pagination = 'false';
+				}				
+			
+		
+			
+			?>			
+							  
+            </ul>
+			
+			</div>
+			<script type="text/javascript">
+			var $jQ = jQuery.noConflict();			
+
+			$jQ(document).ready(function(){
+				$jQ('.tukuslider').bxSlider({
+				slideWidth: <? echo $slider_width; ?>,
+				mode: '<? echo $slider_mode; ?>',
+				minSlides: <? echo $params->get('max_slides'); ?>,
+				maxSlides: <? echo $params->get('max_slides'); ?>,
+				moveSlides: <? echo $params->get('max_slides'); ?>,
+				slideMargin: 10,
+				preloadImages: 'visible',
+				speed: <? echo $params->get('slider_speed'); ?>,
+				pager: <? echo $pagination; ?>,
+				controls: <? echo $navigation; ?>,
+				responsive: <? echo $responsive; ?>,
+				auto: <? echo $auto_slider; ?>
+				});
+			});
+
+			</script>	
+		
+		<?PHP
+		
+
+	break;
+}		
+
+
+
+function MultiSort($data, $sortCriteria, $caseInSensitive = true)
+{
+  if( !is_array($data) || !is_array($sortCriteria))
+    return false;      
+  $args = array();
+  $i = 0;
+  foreach($sortCriteria as $sortColumn => $sortAttributes) 
+  {
+    $colList = array();
+    foreach ($data as $key => $row)
+    {
+      $convertToLower = $caseInSensitive && (in_array(SORT_STRING, $sortAttributes) || in_array(SORT_REGULAR, $sortAttributes));
+      $rowData = $convertToLower ? strtolower($row[$sortColumn]) : $row[$sortColumn];
+      $colLists[$sortColumn][$key] = $rowData;
+    }
+    $args[] = &$colLists[$sortColumn];
+     
+    foreach($sortAttributes as $sortAttribute)
+    {     
+      $tmp[$i] = $sortAttribute;
+      $args[] = &$tmp[$i];
+      $i++;     
+     }
+  }
+  $args[] = &$data;
+  call_user_func_array('array_multisort', $args);
+  return end($args);
+} 
+
+?>
+
+
+
+					
+					


### PR DESCRIPTION

I've added some new features to this module.
Player list can show mins played and players positions and sorted by mins and positions

I've created an alternative template using bxslider. It can show a stickers players card. 
Flag, position, mins played can be enabled or disabled. 
Also it can be configured the number of the players, slider speed, orientation (vertical, horizontal), navigation links and pagination icons.

Pictures below show backend configuration and frontend display.
![team_players02](https://user-images.githubusercontent.com/20923398/92135070-97acf680-ee0a-11ea-8529-d079a630a4e8.png)
![team_players04](https://user-images.githubusercontent.com/20923398/92134013-523bf980-ee09-11ea-9186-9e09778e6584.png)
![team_players01](https://user-images.githubusercontent.com/20923398/92134024-5405bd00-ee09-11ea-879f-5ade3197287d.png)
![team_players03](https://user-images.githubusercontent.com/20923398/92134037-5700ad80-ee09-11ea-91fc-d0c087d56825.png)
