### PR TITLE
Fix View Github in Backend

### DIFF
--- a/admin/models/github.php
+++ b/admin/models/github.php
@@ -164,6 +164,10 @@ class sportsmanagementModelgithub extends BaseDatabaseModel
 		if ($params->get('gh_token', ''))
 		{
 			$gh_options->set('gh.token', $params->get('gh_token', ''));
+
+			$headers = array();
+			$headers['Authorization'] = 'token ' . $params->get('gh_token', '');
+			$gh_options->set('headers', $headers);
 		}
 		/** Set the username and password if set in the params */
 		else


### PR DESCRIPTION
Beim Öffnen der View Github aus den Sonderfunktionen im Backend wird mir dieser Fehler ausgegeben.
![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/a0a33ff0-458c-48e4-aa1c-0e359da6dcfc)

Mit diesem Pull-Request werden mir die letzten Commits wieder angezeigt:
![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/aefbb837-0b07-44f1-9f12-80db6508f2dd)

