### PR TITLE
Fix modal not showing in calendar

### DIFF
--- a/modules/mod_sportsmanagement_calendar/calendarClass.php
+++ b/modules/mod_sportsmanagement_calendar/calendarClass.php
@@ -256,6 +256,7 @@ class PHPCalendar
 						$todaylink = $click;
 						$s         .= $class . 'jlcCalendarTodayLink' . $tdEnd
 							. '<a class="hasTip jlcCalendarToday jlcmodal' . $this->modid . '"'
+							. ' data-bs-toggle="modal" data-bs-target="#myModal' . $this->modid . '"'
 							. ' href="' . $link . '" onclick="' . $click . '"';
 						$s         .= $modalrel . " >$divday</a>";
 					}
@@ -263,6 +264,7 @@ class PHPCalendar
 					{
 						$s .= (($link == "") ? $class . $tdEnd . $divday : "jlcCalendarDay"
 							. $tdEnd . '<a class="jlcCalendarDay hasTip jlcmodal' . $this->modid
+							. '" data-bs-toggle="modal" data-bs-target="#myModal' . $this->modid
 							. '" href="' . $link . '" onclick="' . $click . '"'
 							. $modalrel . " >$divday</a>");
 					}


### PR DESCRIPTION
Bei mir wurde das Popup mit den Spieldetails im Kalender nicht geöffnet.
Mit dieser Änderung öffnet sich das Popup wieder.