### PR TITLE
#1473

### DIFF
--- a/modules/mod_sportsmanagement_calendar/connectors/jevents.php
+++ b/modules/mod_sportsmanagement_calendar/connectors/jevents.php
@@ -37,6 +37,7 @@ class JEventsConnector extends JSMCalendar
 
 		$year  = substr($caldates['start'], 0, 4);
 		$month = (substr($caldates['start'], 5, 1) == '0') ? substr($caldates['start'], 6, 1) : substr($caldates['start'], 5, 2);
+		$month = str_replace('-', '', $month);
 
 		self::$xparams = $params;
 		/**

--- a/modules/mod_sportsmanagement_calendar/mod_sportsmanagement_calendar.php
+++ b/modules/mod_sportsmanagement_calendar/mod_sportsmanagement_calendar.php
@@ -120,6 +120,9 @@ if (!defined('JLC_MODULESCRIPTLOADED'))
 	if (version_compare(JVERSION, '4.0.0', 'ge'))
 	{
 		HTMLHelper::_('script', 'modules' . DIRECTORY_SEPARATOR . $module->module . DIRECTORY_SEPARATOR . 'assets/js' . DIRECTORY_SEPARATOR . $module->module . '.js');
+		$doc->getWebAssetManager()
+    	->useScript('bootstrap.modal');
+
 	}
 	elseif (version_compare(JVERSION, '3.0.0', 'ge'))
 	{

--- a/modules/mod_sportsmanagement_calendar/tmpl/default.php
+++ b/modules/mod_sportsmanagement_calendar/tmpl/default.php
@@ -53,14 +53,14 @@ $show_teamlist = ($params->get('show_teamslist') == 1) ? 'show' : 'hidden';
 		<!-- Modal content-->
 		<div id="myModalcontent<?php echo $module->id; ?>" class="modal-content">
 			<div id="myModalheader<?php echo $module->id; ?>" class="modal-header">
-				<button type="button" class="close" onclick="$('#myModal<?php echo $module->id; ?>').modal('hide');">&times;</button>
+				<button type="button" class="close" data-bs-dismiss="modal">&times;</button>
 				<h4 class="modal-title">Modal Header</h4>
 			</div>
 			<div id="myModalbody<?php echo $module->id; ?>" class="modal-body">
 				<p>Some text in the modal.</p>
 			</div>
 			<div id="myModalfooter<?php echo $module->id; ?>" class="modal-footer">
-				<button type="button" class="btn btn-default" onclick="$('#myModal<?php echo $module->id; ?>').modal('hide');">Close</button>
+				<button type="button" class="btn btn-default" data-bs-dismiss="modal">Close</button>
 			</div>
 		</div>
 

--- a/modules/mod_sportsmanagement_calendar/tmpl/default_jsm.php
+++ b/modules/mod_sportsmanagement_calendar/tmpl/default_jsm.php
@@ -51,14 +51,14 @@ $show_teamlist = ($params->get('show_teamslist') == 1) ? 'show' : 'hidden';
 		<!-- Modal content-->
 		<div id="myModalcontent<?php echo $module->id; ?>" class="modal-content">
 			<div id="myModalheader<?php echo $module->id; ?>" class="modal-header">
-				<button type="button" class="close" onclick="$('#myModal<?php echo $module->id; ?>').modal('hide');">&times;</button>
+				<button type="button" class="close" data-bs-dismiss="modal">&times;</button>
 				<h4 class="modal-title">Modal Header</h4>
 			</div>
 			<div id="myModalbody<?php echo $module->id; ?>" class="modal-body">
 				<p>Some text in the modal.</p>
 			</div>
 			<div id="myModalfooter<?php echo $module->id; ?>" class="modal-footer">
-				<button type="button" class="btn btn-default" onclick="$('#myModal<?php echo $module->id; ?>').modal('hide');">Close</button>
+				<button type="button" class="btn btn-default" data-bs-dismiss="modal">Close</button>
 			</div>
 		</div>
 


### PR DESCRIPTION
Fix get month from caldates in JEvents
Joomla 4 load bootstrap.modal with WebAssetManager 
Revert JS-Code for closing modal with data-bs-dismiss

Mit den Änderungen funktioniert es bei mir in Joomla 3 und 4.