### PR TITLE
Fix dependsql

### DIFF
--- a/admin/controllers/ajax.json.php
+++ b/admin/controllers/ajax.json.php
@@ -630,10 +630,10 @@ class sportsmanagementControllerAjax extends BaseController
 		{
 			$result = $this->getModel('ajax')->getProjectTeamsByDivisionOptions(
 				$this->jinput->get->getString('p'),
-				$this->jinput->get->getString('division'),
 				$this->jinput->get->getString('required'),
 				$this->jinput->get->getString('slug'),
-				$this->jinput->get->getString('dbase')
+				$this->jinput->get->getString('dbase'),
+				$this->jinput->get->getString('division')
 			);
 
 			echo new JsonResponse($result);

--- a/admin/controllers/ajax.php
+++ b/admin/controllers/ajax.php
@@ -297,7 +297,7 @@ class sportsmanagementControllerAjax extends BaseController
 		$app    = Factory::getApplication();
 		$jinput = $app->input;
 		$model  = $this->getModel('ajax');
-		echo json_encode((array) $model->getProjectTeamsByDivisionOptions($jinput->getVar('p', '0'), Factory::getApplication()->input->getInt('division'), $jinput->getVar('required', 'false'), $jinput->getVar('slug', 'false'), Factory::getApplication()->input->getInt('dbase')));
+		echo json_encode((array) $model->getProjectTeamsByDivisionOptions($jinput->getVar('p', '0'), $jinput->getVar('required', 'false'), $jinput->getVar('slug', 'false'), Factory::getApplication()->input->getInt('dbase'), Factory::getApplication()->input->getInt('division')));
 		Factory::getApplication()->close();
 	}
 

--- a/admin/models/ajax.php
+++ b/admin/models/ajax.php
@@ -1030,7 +1030,7 @@ $app->enqueueMessage(Text::_(__METHOD__ . ' ' . ' ' . __LINE__ . ' ' . 'person_a
 	 *
 	 * @return
 	 */
-	public static function getProjectTeamsByDivisionOptions($project_id, $division_id = 0, $required = false, $slug = false, $dbase = false)
+	public static function getProjectTeamsByDivisionOptions($project_id, $required = false, $slug = false, $dbase = false, $division_id = 0)
 	{
 
 		$app    = Factory::getApplication();
@@ -1850,7 +1850,7 @@ $app->enqueueMessage(Text::_(__METHOD__ . ' ' . ' ' . __LINE__ . ' ' . 'person_a
 	 *
 	 * @return
 	 */
-	function getRefereesOptions($project_id, $required = false, $slug = false, $dbase = false)
+	public static function getRefereesOptions($project_id, $required = false, $slug = false, $dbase = false)
 	{
 
 		$app    = Factory::getApplication();
@@ -1877,7 +1877,23 @@ $app->enqueueMessage(Text::_(__METHOD__ . ' ' . ' ' . __LINE__ . ' ' . 'person_a
 		$query->join('INNER', ' #__sportsmanagement_project_referee AS pr ON pr.person_id = sp.id ');
 
 		// Where
-		$query->where('pr.project_id = ' . $db->Quote($project_id));
+		if ($project_id)
+		{
+			if (!is_array($project_id))
+			{
+				$project_id = explode(",", $project_id);
+			}
+
+			if (is_array($project_id))
+			{
+				$ids = implode(",", array_map('intval', $project_id));
+				$query->where('pr.project_id IN (' . $ids . ')');
+			}
+			else
+			{
+				$query->where('pr.project_id = ' . (int) $project_id);
+			}
+		}
 		$query->where('p.published = 1');
 
 		// Order

--- a/site/views/clubs/tmpl/default.xml
+++ b/site/views/clubs/tmpl/default.xml
@@ -48,6 +48,8 @@
 			
 			
 			<field	name="division" type="dependsql" depends="p" task="projectdivisionsoptions"
+					key_field="project_id"
+					value_field="p"
 					label="COM_SPORTSMANAGEMENT_XML_SELECT_DIVISION_LABEL"
 					description="COM_SPORTSMANAGEMENT_XML_SELECT_DIVISION_DESCR"
 					required="false">

--- a/site/views/matchreport/tmpl/default.xml
+++ b/site/views/matchreport/tmpl/default.xml
@@ -28,7 +28,7 @@
       key_field="season_id"
 					label="COM_SPORTSMANAGEMENT_XML_SELECT_SEASON_LABEL"
 					description="COM_SPORTSMANAGEMENT_XML_SELECT_SEASON_DESCR"
-					required="">
+					required="true">
 			</field>
 			
 			<field	name="p" 
@@ -39,15 +39,17 @@
 			value_field="s"
 					label="COM_SPORTSMANAGEMENT_XML_SELECT_PROJECT_LABEL"
 					description="COM_SPORTSMANAGEMENT_XML_SELECT_PROJECT_DESCR"
-					required=""
+					required="true"
           size="">
 			</field>
 			
-			<field	name="mid" type="dependsql" depends="p" task="matchesoptions" 
+			<field	name="mid" type="dependsql" depends="p" task="matchesoptions"
+			key_field="project_id"
+			value_field="p" 
 					label="COM_SPORTSMANAGEMENT_XML_MATCHREPORT_SELECT_MATCH_LABEL"
 					description="COM_SPORTSMANAGEMENT_XML_MATCHREPORT_SELECT_MATCH_DESCR"
 					
-					required="false">
+					required="true">
 			</field>
 
 		</fieldset>

--- a/site/views/referee/tmpl/default.xml
+++ b/site/views/referee/tmpl/default.xml
@@ -43,6 +43,8 @@
 					required="">
 			</field>
 			<field	name="pid" type="dependsql" depends="p" task="refereesoptions"
+					key_field="project_id"
+					value_field="p"
 					label="COM_SPORTSMANAGEMENT_XML_SELECT_REFEREE_LABEL"
 					description="COM_SPORTSMANAGEMENT_XML_SELECT_REFEREE_DESCR"
 					required="">

--- a/site/views/treetonode/tmpl/default.xml
+++ b/site/views/treetonode/tmpl/default.xml
@@ -47,9 +47,11 @@
 			</field>
       
 			<field	name="tnid" 
-      type="dependsql" 
-      depends="p" 
-      task="projecttreenodeoptions"
+	      			type="dependsql" 
+      				depends="p" 
+      				task="projecttreenodeoptions"
+  					key_field="project_id"
+					value_field="p"
 					label="COM_SPORTSMANAGEMENT_XML_TREETO_SELECT_TREETONODE_LABEL" 
 					description="COM_SPORTSMANAGEMENT_XML_TREETO_SELECT_TREETONODE_DESCR"
 					required="false">


### PR DESCRIPTION
Bei manchen Menüeinträgen konnten abhängige Felder wie z.B. Division, Schiedsrichter oder Mannschaften nicht geladen werden.