### PR TITLE
Fix missing project_type in currentseasons

### DIFF
--- a/admin/models/currentseasons.php
+++ b/admin/models/currentseasons.php
@@ -66,7 +66,7 @@ class sportsmanagementModelcurrentseasons extends JSMModelList
 		$filter_season = ComponentHelper::getParams($this->jsmoption)->get('current_season', 0);
 
 		$this->jsmquery->clear();
-		$this->jsmquery->select('p.id,p.project_art_id,p.project_type,p.name,st.name AS sportstype,s.name AS season,l.name AS league,l.country AS country,u.name AS editor');
+		$this->jsmquery->select('p.id,p.project_art_id,p.project_type,p.name,p.teams_as_referees,st.name AS sportstype,s.name AS season,l.name AS league,l.country AS country,u.name AS editor');
 
 		$this->jsmquery->from('#__sportsmanagement_project AS p');
 		$this->jsmquery->join('LEFT', '#__sportsmanagement_season AS s ON s.id = p.season_id');

--- a/admin/models/currentseasons.php
+++ b/admin/models/currentseasons.php
@@ -66,7 +66,7 @@ class sportsmanagementModelcurrentseasons extends JSMModelList
 		$filter_season = ComponentHelper::getParams($this->jsmoption)->get('current_season', 0);
 
 		$this->jsmquery->clear();
-		$this->jsmquery->select('p.id,p.project_art_id,p.name,st.name AS sportstype,s.name AS season,l.name AS league,l.country AS country,u.name AS editor');
+		$this->jsmquery->select('p.id,p.project_art_id,p.project_type,p.name,st.name AS sportstype,s.name AS season,l.name AS league,l.country AS country,u.name AS editor');
 
 		$this->jsmquery->from('#__sportsmanagement_project AS p');
 		$this->jsmquery->join('LEFT', '#__sportsmanagement_season AS s ON s.id = p.season_id');

--- a/admin/views/cpanel/tmpl/default_4.php
+++ b/admin/views/cpanel/tmpl/default_4.php
@@ -197,7 +197,7 @@ echo $this->loadTemplate('start_menu');
 					<ul class="nav flex-wrap" style="grid-gap: 0.5rem; grid-template-columns: repeat(auto-fit,minmax(120px,1fr));">
 						<li class="quickicon quickicon-single">
 							<a title="<?php echo Text::_('COM_SPORTSMANAGEMENT_D_MENU_CLUBS') ?>" 
-							href="index.php?option=com_sportsmanagement&view=vereine">
+							href="index.php?option=com_sportsmanagement&view=clubs">
 								<div class="quickicon-icon">
 									<img src="components/com_sportsmanagement/assets/icons/vereine.png" style="background-color:white;"
 										alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_D_MENU_CLUBS') ?>"/>

--- a/admin/views/currentseasons/tmpl/default.php
+++ b/admin/views/currentseasons/tmpl/default.php
@@ -172,19 +172,24 @@ require(JPATH_COMPONENT_ADMINISTRATOR . '/views/listheader/tmpl/default_4_start_
 												</li>
 											<?PHP
 											}
+											if (isset($item->teams_as_referees) && $item->teams_as_referees == 0 )
+											{
 											?>
-											<li class="quickicon quickicon-single">
-												<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $item->count_projectreferees) ?>"
-												href="index.php?option=com_sportsmanagement&view=projectreferees&persontype=3&pid=<?PHP echo $item->id; ?>">
-													<div class="quickicon-icon">
-														<img src="components/com_sportsmanagement/assets/icons/projektschiedsrichter.png" style="background-color:white;"
-															alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $item->count_projectreferees) ?>"/>
-													</div>
-													<div class="quickicon-name d-flex align-items-end">
-														<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $item->count_projectreferees) ?>
-													</div>
-												</a>
-											</li>
+												<li class="quickicon quickicon-single">
+													<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $item->count_projectreferees) ?>"
+													href="index.php?option=com_sportsmanagement&view=projectreferees&persontype=3&pid=<?PHP echo $item->id; ?>">
+														<div class="quickicon-icon">
+															<img src="components/com_sportsmanagement/assets/icons/projektschiedsrichter.png" style="background-color:white;"
+																alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $item->count_projectreferees) ?>"/>
+														</div>
+														<div class="quickicon-name d-flex align-items-end">
+															<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $item->count_projectreferees) ?>
+														</div>
+													</a>
+												</li>
+											<?PHP
+											}
+											?>
 											<li class="quickicon quickicon-single">
 												<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_TEAMS', $item->count_projectteams) ?>"
 												href="index.php?option=com_sportsmanagement&view=projectteams&pid=<?PHP echo $item->id; ?>">

--- a/admin/views/currentseasons/tmpl/default.php
+++ b/admin/views/currentseasons/tmpl/default.php
@@ -124,10 +124,10 @@ require(JPATH_COMPONENT_ADMINISTRATOR . '/views/listheader/tmpl/default_4_start_
 													href="index.php?option=com_sportsmanagement&view=divisions&pid=<?PHP echo $item->id; ?>">
 														<div class="quickicon-icon">
 															<img src="components/com_sportsmanagement/assets/icons/divisionen.png" style="background-color:white;"
-																alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS') ?>"/>
+																alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS', $item->count_projectdivisions) ?>"/>
 														</div>
 														<div class="quickicon-name d-flex align-items-end">
-															<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS') ?>
+															<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS', $item->count_projectdivisions) ?>
 														</div>
 													</a>
 												</li>

--- a/admin/views/project/tmpl/panel_4.php
+++ b/admin/views/project/tmpl/panel_4.php
@@ -42,88 +42,145 @@ echo $this->loadTemplate('jsm_warnings');
 echo $this->loadTemplate('jsm_notes');			    
 echo $this->loadTemplate('jsm_tips');			    
 ?>		    
-    <div id="dashboard-iconss" class="dashboard-icons">
-        <a class="btn btn-jsm-dash"
-           href="index.php?option=com_sportsmanagement&task=project.edit&id=<?PHP echo $this->project->id; ?>">
-            <img src="components/com_sportsmanagement/assets/icons/projekte.png"
-                 alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_PSETTINGS') ?>"/><br/>
-            <span><?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_PSETTINGS') ?></span>
-        </a>
-        <a class="btn btn-jsm-dash"
-           href="index.php?option=com_sportsmanagement&view=templates&pid=<?PHP echo $this->project->id; ?>">
-            <img src="components/com_sportsmanagement/assets/icons/templates.png"
-                 alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_FES') ?>"/><br/>
-            <span><?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_FES') ?></span>
-        </a>
-		<?php
-		if ((isset($this->project->project_type))
-			&& (($this->project->project_type == 'PROJECT_DIVISIONS')
-				|| ($this->project->project_type == 'DIVISIONS_LEAGUE'))
-		)
-		{
-			?>
-            <a class="btn btn-jsm-dash"
-               href="index.php?option=com_sportsmanagement&view=divisions&pid=<?PHP echo $this->project->id; ?>">
-                <img src="components/com_sportsmanagement/assets/icons/divisionen.png"
-                     alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS', $this->count_projectdivisions) ?>"/><br/>
-                <span><?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS', $this->count_projectdivisions) ?></span>
-            </a>
-			<?php
-		}
+    <div class="card mb-3">
+		<nav class="quick-icons px-3 py-3">
+			<ul class="nav flex-wrap" style="grid-gap: 0.5rem; grid-template-columns: repeat(auto-fit,minmax(180px,1fr));">
+				<li class="quickicon quickicon-single">
+					<a title="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_PSETTINGS') ?>"
+					href="index.php?option=com_sportsmanagement&task=project.edit&id=<?PHP echo $this->project->id; ?>">
+						<div class="quickicon-icon">
+							<img src="components/com_sportsmanagement/assets/icons/projekte.png" style="background-color:white;"
+								alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_PSETTINGS') ?>"/>
+						</div>
+						<div class="quickicon-name d-flex align-items-end">
+							<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_PSETTINGS') ?>
+						</div>
+					</a>
+				</li>
+				<li class="quickicon quickicon-single">
+					<a title="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_FES') ?>"
+					href="index.php?option=com_sportsmanagement&view=templates&pid=<?PHP echo $this->project->id; ?>">
+						<div class="quickicon-icon">
+							<img src="components/com_sportsmanagement/assets/icons/templates.png" style="background-color:white;"
+								alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_FES') ?>"/>
+						</div>
+						<div class="quickicon-name d-flex align-items-end">
+							<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_FES') ?>
+						</div>
+					</a>
+				</li>
+				<?php
+				if ((isset($this->project->project_type))
+					&& (($this->project->project_type == 'PROJECT_DIVISIONS')
+						|| ($this->project->project_type == 'DIVISIONS_LEAGUE'))
+				)
+				{
+				?>
+					<li class="quickicon quickicon-single">
+						<a title="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS') ?>"
+						href="index.php?option=com_sportsmanagement&view=divisions&pid=<?PHP echo $this->project->id; ?>">
+							<div class="quickicon-icon">
+								<img src="components/com_sportsmanagement/assets/icons/divisionen.png" style="background-color:white;"
+									alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS', $this->count_projectdivisions) ?>"/>
+							</div>
+							<div class="quickicon-name d-flex align-items-end">
+								<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_DIVISIONS', $this->count_projectdivisions) ?>
+							</div>
+						</a>
+					</li>
+				<?php
+				}
 
+				if ((isset($this->project->project_type))
+					&& (($this->project->project_type == 'TOURNAMENT_MODE')
+						|| ($this->project->project_type == 'DIVISIONS_LEAGUE'))
+				)
+				{
+				?>
+					<li class="quickicon quickicon-single">
+						<a title="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_TREE') ?>"
+						href="index.php?option=com_sportsmanagement&view=treetos&pid=<?PHP echo $this->project->id; ?>">
+							<div class="quickicon-icon">
+								<img src="components/com_sportsmanagement/assets/icons/turnierbaum.png" style="background-color:white;"
+									alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_TREE') ?>"/>
+							</div>
+							<div class="quickicon-name d-flex align-items-end">
+								<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_TREE') ?>
+							</div>
+						</a>
+					</li>
+				<?PHP
+				}
 
-		if ((isset($this->project->project_type))
-			&& (($this->project->project_type == 'TOURNAMENT_MODE')
-				|| ($this->project->project_type == 'DIVISIONS_LEAGUE'))
-		)
-		{
-			?>
-            <a class="btn btn-jsm-dash"
-               href="index.php?option=com_sportsmanagement&view=treetos&pid=<?PHP echo $this->project->id; ?>">
-                <img src="components/com_sportsmanagement/assets/icons/turnierbaum.png"
-                     alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_TREE') ?>"/><br/>
-                <span><?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_TREE') ?></span>
-            </a>
-			<?PHP
-		}
+				if ($this->project->project_art_id != 3)
+				{
+				?>
+					<li class="quickicon quickicon-single">
+						<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_POSITIONS', $this->count_projectpositions) ?>"
+						href="index.php?option=com_sportsmanagement&view=projectpositions&pid=<?PHP echo $this->project->id; ?>">
+							<div class="quickicon-icon">
+								<img src="components/com_sportsmanagement/assets/icons/positionen.png" style="background-color:white;"
+								alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_POSITIONS', $this->count_projectpositions) ?>"/>
+							</div>
+							<div class="quickicon-name d-flex align-items-end">
+								<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_POSITIONS', $this->count_projectpositions) ?>
+							</div>
+						</a>
+					</li>
+				<?PHP
+				}
+				?>
+				<li class="quickicon quickicon-single">
+					<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $this->count_projectreferees) ?>"
+					href="index.php?option=com_sportsmanagement&view=projectreferees&persontype=3&pid=<?PHP echo $this->project->id; ?>">
+						<div class="quickicon-icon">
+							<img src="components/com_sportsmanagement/assets/icons/projektschiedsrichter.png" style="background-color:white;"
+								alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $this->count_projectreferees) ?>"/>
+						</div>
+						<div class="quickicon-name d-flex align-items-end">
+							<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $this->count_projectreferees) ?>
+						</div>
+					</a>
+				</li>
+				<li class="quickicon quickicon-single">
+					<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_TEAMS', $this->count_projectteams) ?>"
+					href="index.php?option=com_sportsmanagement&view=projectteams&pid=<?PHP echo $this->project->id; ?>">
+						<div class="quickicon-icon">
+							<img src="components/com_sportsmanagement/assets/icons/mannschaften.png" style="background-color:white;"
+								alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_TEAMS', $this->count_projectteams) ?>"/>
+						</div>
+						<div class="quickicon-name d-flex align-items-end">
+							<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_TEAMS', $this->count_projectteams) ?>
+						</div>
+					</a>
+				</li>
+				<li class="quickicon quickicon-single">
+					<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_MATCHDAYS', $this->count_matchdays) ?>"
+					href="index.php?option=com_sportsmanagement&view=rounds&pid=<?PHP echo $this->project->id; ?>">
+						<div class="quickicon-icon">
+							<img src="components/com_sportsmanagement/assets/icons/spieltage.png" style="background-color:white;"
+								alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_MATCHDAYS', $this->count_matchdays) ?>"/>
+						</div>
+						<div class="quickicon-name d-flex align-items-end">
+							<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_MATCHDAYS', $this->count_matchdays) ?>
+						</div>
+					</a>
+				</li>
+				<li class="quickicon quickicon-single">
+					<a title="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_XML_EXPORT') ?>"
+					href="index.php?option=com_sportsmanagement&view=jlxmlexports&pid=<?PHP echo $this->project->id; ?>">
+						<div class="quickicon-icon">
+							<img src="components/com_sportsmanagement/assets/icons/xmlexport.png" style="background-color:white;"
+								alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_XML_EXPORT') ?>"/>
+						</div>
+						<div class="quickicon-name d-flex align-items-end">
+							<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_XML_EXPORT') ?>
+						</div>
+					</a>
+				</li>
 
-
-		if ($this->project->project_art_id != 3)
-		{
-			?>
-            <a class="btn btn-jsm-dash"
-               href="index.php?option=com_sportsmanagement&view=projectpositions&pid=<?PHP echo $this->project->id; ?>">
-                <img src="components/com_sportsmanagement/assets/icons/positionen.png"
-                     alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_POSITIONS', $this->count_projectpositions) ?>"/><br/>
-                <span><?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_POSITIONS', $this->count_projectpositions) ?></span>
-            </a>
-			<?PHP
-		}
-		?>
-        <a class="btn btn-jsm-dash"
-           href="index.php?option=com_sportsmanagement&view=projectreferees&persontype=3&pid=<?PHP echo $this->project->id; ?>">
-            <img src="components/com_sportsmanagement/assets/icons/projektschiedsrichter.png"
-                 alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $this->count_projectreferees) ?>"/><br/>
-            <span><?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $this->count_projectreferees) ?></span>
-        </a>
-        <a class="btn btn-jsm-dash"
-           href="index.php?option=com_sportsmanagement&view=projectteams&pid=<?PHP echo $this->project->id; ?>">
-            <img src="components/com_sportsmanagement/assets/icons/mannschaften.png"
-                 alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_TEAMS', $this->count_projectteams) ?>"/><br/>
-            <span><?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_TEAMS', $this->count_projectteams) ?></span>
-        </a>
-        <a class="btn btn-jsm-dash"
-           href="index.php?option=com_sportsmanagement&view=rounds&pid=<?PHP echo $this->project->id; ?>">
-            <img src="components/com_sportsmanagement/assets/icons/spieltage.png"
-                 alt="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_MATCHDAYS', $this->count_matchdays) ?>"/><br/>
-            <span><?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_MATCHDAYS', $this->count_matchdays) ?></span>
-        </a>
-        <a class="btn btn-jsm-dash"
-           href="index.php?option=com_sportsmanagement&view=jlxmlexports&pid=<?PHP echo $this->project->id; ?>">
-            <img src="components/com_sportsmanagement/assets/icons/xmlexport.png"
-                 alt="<?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_XML_EXPORT') ?>"/><br/>
-            <span><?php echo Text::_('COM_SPORTSMANAGEMENT_P_PANEL_XML_EXPORT') ?></span>
-        </a>
+			</ul>
+		</nav>
     </div>
     </div>
     <div class="col-md-2">

--- a/admin/views/project/tmpl/panel_4.php
+++ b/admin/views/project/tmpl/panel_4.php
@@ -129,6 +129,8 @@ echo $this->loadTemplate('jsm_tips');
 					</li>
 				<?PHP
 				}
+				if (isset($item->teams_as_referees) && $item->teams_as_referees == 0 )
+				{
 				?>
 				<li class="quickicon quickicon-single">
 					<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_REFEREES', $this->count_projectreferees) ?>"
@@ -142,6 +144,9 @@ echo $this->loadTemplate('jsm_tips');
 						</div>
 					</a>
 				</li>
+				<?PHP
+				}
+				?>
 				<li class="quickicon quickicon-single">
 					<a title="<?php echo Text::plural('COM_SPORTSMANAGEMENT_P_PANEL_TEAMS', $this->count_projectteams) ?>"
 					href="index.php?option=com_sportsmanagement&view=projectteams&pid=<?PHP echo $this->project->id; ?>">


### PR DESCRIPTION
In der Aktuellen Saison werden die Divisionen und Baum wegen des fehlenden SQL-Abfrage der project_type nicht angezeigt.

Zusätzlich habe ich das Layout auch für die Projektansicht angepasst:
![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/0310d0b5-49ef-44e7-904d-1cf0f9b0688c)

Und wenn in den Projekteinstellungen die Option "Mannschaft als Schiedsrichter" aktiv ist (verwenden wir bei Faustball) dann können wir diesen Button in der Ansicht auch ausblenden.