### PR TITLE
Template Override

### DIFF
--- a/admin/helpers/sportsmanagement.php
+++ b/admin/helpers/sportsmanagement.php
@@ -1670,7 +1670,8 @@ try
 		foreach ($templatesToLoad as $template)
 		{
 			$view->addTemplatePath(JPATH_COMPONENT . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . $template . DIRECTORY_SEPARATOR . 'tmpl');
-
+			$view->addTemplatePath(JPATH_THEMES . '/' . Factory::getApplication()->getTemplate() . '/html/com_sportsmanagement/' . $template);
+			
 			if (is_array($extensions) && count($extensions) > 0)
 			{
 				foreach ($extensions as $e => $extension)


### PR DESCRIPTION
#1066
In der Methode addTemplatePaths wird mit addTemplatePath() der zu suchende Pfad für die listheader oder globalviews hinzugefügt. Joomla weiß aber nichts davon, dass es auch im jeweiligen Template nach Overrides suchen könnte. Deswegen muss auch dieser Pfad in der Methode hinzugefügt werden.

Erst damit funktioniert auch für diese Views ein Override.