### PR TITLE
Fix logo in module clubicons

### DIFF
--- a/modules/mod_sportsmanagement_clubicons/helper.php
+++ b/modules/mod_sportsmanagement_clubicons/helper.php
@@ -196,6 +196,6 @@ class modJSMClubiconsHelper
 
 		$imgtitle = Text::_('View ') . $item->name;
 
-		return HTMLHelper::image($logourl, $item->name, 'border="0" style="width:auto; height:' . $this->params->get('picture_height') . 'px" class="' . $class . '" title="' . $imgtitle . '"');
+		return HTMLHelper::image($logourl, $item->name, array('style' => 'width:auto; height:' . $this->params->get('picture_height') . 'px', 'title' => $imgtitle, ' border' => 0, ' class' => $class));
 	}
 }

--- a/modules/mod_sportsmanagement_clubicons/mod_sportsmanagement_clubicons.php
+++ b/modules/mod_sportsmanagement_clubicons/mod_sportsmanagement_clubicons.php
@@ -123,7 +123,7 @@ $transition = (100 + $percent)/100;
 $style = '
 .img-zoom {
 width: auto;
-    height: ' . $params->get('picture_height', '50') . ';
+    height: ' . $params->get('picture_height', '50') . px';
     -webkit-transition: all .2s ease-in-out;
     -moz-transition: all .2s ease-in-out;
     -o-transition: all .2s ease-in-out;


### PR DESCRIPTION
Die Größenangabe wird nicht berücksichtigt und die Attribute sollten als Array übergeben werden. Wenn im Vereinsnamen ein Leerzeichen enthalten ist bringt das den Code durcheinander.

Vorher:
![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/6d06c3ed-b5ec-4bac-b500-d6740121cc80)

![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/47c643be-0f3e-482e-bd8e-a9fec02d1b9a)

Nachher:
![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/5471642e-3bca-409d-8d2d-eead3ab7c4ab)

![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/ea706b78-ffc6-46da-9263-c5699b83f597)
