### PR TITLE
Remove !important from css for Icomoon

### DIFF
--- a/admin/assets/css/extended-1.1.css
+++ b/admin/assets/css/extended-1.1.css
@@ -191,7 +191,7 @@ input.blue-btn:hover{background-color:#6AA0CF;cursor:pointer}
 .social-media a i{position:relative;top:3px}
 .social-media .icon-mail:before{font-size:15px;font-weight:400;top:2px;position:relative}
 .social-media em{font-style:normal;position:relative;top:2px}
-a.previous-page,a.next-page{background:#ededed;color:#616161;text-align:center;margin-top:53px;position:relative;font-size:22px;font-family:'icomoon'!important}
+a.previous-page,a.next-page{background:#ededed;color:#616161;text-align:center;margin-top:53px;position:relative;font-size:22px;font-family:'icomoon'}
 a.previous-page:hover,a.next-page:hover{text-decoration:none;background:#1ebba3;color:#fff}
 a.previous-page{margin-right:35px;z-index:9}
 a.next-page{margin-right:-67px;z-index:8}

--- a/admin/assets/css/style.css
+++ b/admin/assets/css/style.css
@@ -11,7 +11,7 @@
 
 [class^="icon-"], [class*=" icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: 'icomoon' !important;
+  font-family: 'icomoon' ;
   speak: none;
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
In meiner Joomla 4-Installation werden mir durch die Vermischung zwischen Icomoon und FontAwesome (was ja bei Joomla nun dabei ist) manche Icons nicht mehr korrekt dargestellt.

![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/1edc453d-9616-4368-8250-1b893af7c8ef)

Wenn ich aber im CSS das "!important" entferne, funktioniert es soweit. Getestet habe ich es mit Joomla 3 und Joomla 4.

![grafik](https://github.com/diddipoeler/sportsmanagement/assets/15192502/3441ed69-b939-4495-b355-f98e2faac611)
