### PR TITLE
Hide a person on roster when the person should not be shown on frontend

### DIFF
--- a/site/models/roster.php
+++ b/site/models/roster.php
@@ -305,6 +305,7 @@ $app    = Factory::getApplication();
 		//$query->where('pos.persontype = ' . $persontype);
 		$query->where('tp.season_id = ' . self::$seasonid);
       $query->where('tp.team_id = ' . $projectteam->season_team_id);
+      $query->where('pr.show_on_frontend = 1');
       
       //$query->where('st.season_id = ' . self::$seasonid);
 		//$query->where('pt.project_id = ' . self::$projectid);


### PR DESCRIPTION
In den Einstellungen zu einer Person kann man "Zeige in Frontend" einstellen. Diese Einstellung wird bei der Kaderansicht allerdings ignoriert.