### PR TITLE
#1682

### DIFF
--- a/site/helpers/ranking.php
+++ b/site/helpers/ranking.php
@@ -616,8 +616,8 @@ class JSMRanking extends \stdClass
             $home->sum_points = ( $home->cnt_won * $win_points ) + ( $home->cnt_draw * $draw_points );
 			$away->sum_points = ( $away->cnt_won * $win_points ) + ( $away->cnt_draw * $draw_points );
                 
-				$home->neg_points = ( $home->cnt_lost * $loss_points ) + ( $home->cnt_draw * $draw_points );
-				$away->neg_points = ( $away->cnt_lost * $loss_points ) + ( $away->cnt_draw * $draw_points );
+				$home->neg_points = ( $home->cnt_lost * $win_points ) + ( $home->cnt_draw * $draw_points );
+				$away->neg_points = ( $away->cnt_lost * $win_points ) + ( $away->cnt_draw * $draw_points );
 			}
             
             


### PR DESCRIPTION
Man wird irre bei so vielen falsch vermuteten nicht zutreffenden Bemerkungen. Fakt bei den Negativpunkten ist, dass dies so gezählt wird: 2 Punkte Regelung 2/1/0. Bei 30 Spielen sind gesamt 60 Punkte zu vergeben.
Bei einer Mannschaft die 20 Spiele gewinnt, 8 Unentschieden und 2 verlorenen Spielen hat schaut es so aus (20 * 2) + (8 * 1) sind 48 +Punkte. Negative Punkte ergeben sich aus (2 * 2) + (8*1) sind 12 Punkte Also ergibt sich daraus 48:12 === Gesamt wieder 60 Punkte. Wer es noch immer nicht versteht - Auch bei Unentschieden verliert man einen Punkt - aber man gewinnt auch einen.