### PR TITLE
#1685

### DIFF
--- a/site/models/nextmatch.php
+++ b/site/models/nextmatch.php
@@ -32,6 +32,7 @@ class sportsmanagementModelNextMatch extends BaseDatabaseModel
 	static $cfg_which_database = 0;
 	var $project = null;
 	var $divisionid = 0;
+	var $divisionid2 = 0;
 	var $ranking = null;
 	var $teams = null;
 	/**
@@ -298,6 +299,7 @@ class sportsmanagementModelNextMatch extends BaseDatabaseModel
 			 *             determined for a division, if the team is part of a division
 			 */
 			$this->divisionid = $team1->division_id;
+			$this->divisionid2 = $team2->division_id;
 		}
 
 		return $this->teams;
@@ -853,7 +855,11 @@ class sportsmanagementModelNextMatch extends BaseDatabaseModel
 		if (empty($this->ranking))
 		{
 			$project  = sportsmanagementModelProject::getProject(self::$cfg_which_database);
-			$division = $this->divisionid;
+			$division = $this->divisionid;			
+			if ($this->divisionid != $this->divisionid2)
+			{
+				$division = 0;
+			}
 			$ranking  = JSMRanking::getInstance($project, self::$cfg_which_database);
 			$ranking->setProjectId($project->id, self::$cfg_which_database);
 			$this->ranking = $ranking->getRanking(0, sportsmanagementModelProject::getCurrentRound(null, self::$cfg_which_database), $division, self::$cfg_which_database);

--- a/site/models/stats.php
+++ b/site/models/stats.php
@@ -331,6 +331,7 @@ class sportsmanagementModelStats extends BaseDatabaseModel
 			}
 
 			$query->where('matches.published = 1');
+			$query->where('matches.crowd > 0 ');
 			$query->group('matches.projectteam1_id');
 			$query->order('avgspectatorspt DESC');
 


### PR DESCRIPTION
In den Projektstatistiken ist das Zuschauerranking auf die gesamt angelegten Spiele. Das verfälscht innerhalb der Saison die durchschnittliche Zuschauerzahl, als auch die %-Auslastung.

Mit der Änderung werden im Zuschauerranking nur Spiele im Projekt berücksichtigt, die auch Zuschauer eingetragen haben.